### PR TITLE
spec->root-sym now support "anonymous" specs

### DIFF
--- a/src/com/wsscode/spec_inspec.cljc
+++ b/src/com/wsscode/spec_inspec.cljc
@@ -15,7 +15,9 @@
 (defn safe-form
   "Return the spec form or nil."
   [spec]
-  (if (contains? (s/registry) spec)
+  (if (or (contains? (s/registry) spec)
+          (fn? spec)
+          (s/spec? spec))
     (s/form spec)))
 
 (defn form->spec

--- a/test/com/wsscode/spec_inspec_test.clj
+++ b/test/com/wsscode/spec_inspec_test.clj
@@ -17,6 +17,8 @@
 
 (deftest test-spec->root-sym
   (is (= (spec->root-sym ::number) `int?))
+  (is (= (spec->root-sym int?) `int?))
+  (is (= (spec->root-sym (s/spec int?)) `int?))
   (is (= (spec->root-sym ::number-strict) `int?))
   (is (= (spec->root-sym ::derived) `int?)))
 


### PR DESCRIPTION
It should allow to use things like
`(sc/coerce string? 42) ;; => "42"`